### PR TITLE
docs: Add detailed playbook instructions for each project

### DIFF
--- a/eureka_deploy/PLAYBOOK-INSTRUCTIONS.md
+++ b/eureka_deploy/PLAYBOOK-INSTRUCTIONS.md
@@ -1,0 +1,38 @@
+# Playbook Instructions for `eureka_deploy`
+
+This document provides detailed instructions on how to run the Ansible playbook in this project to deploy a Eureka server cluster.
+
+## 1. `deploy-eureka-cluster.yml`
+
+This playbook deploys a 3-node Eureka server cluster.
+
+### a. How to Run
+
+1.  **Configure your environment:**
+    -   Open the `ansible/hosts` file.
+    -   Update the `eureka_nodes` list with the IP addresses of your servers.
+    -   Update the `ansible_user` and `ansible_password` variables with your SSH credentials.
+    -   Place your compiled Eureka server `.jar` file in the `eureka_deploy` directory.
+
+2.  **Run the playbook:**
+    ```bash
+    ansible-playbook -i ansible/hosts ansible/deploy-eureka-cluster.yml
+    ```
+
+### b. Playbook Steps
+
+1.  **Install Prerequisites:** The playbook first installs Docker, Docker Compose, and the required Python libraries on all the target servers.
+2.  **Create Deployment Directory:** It then creates a deployment directory at `/opt/eureka`.
+3.  **Copy Docker Compose file:** The `docker-compose.yml` file is copied to the deployment directory.
+4.  **Generate `application.yml`:** A unique `application.yml` file is generated for each node from the `application.yml.j2` template. This file configures each node to peer with the other nodes in the cluster.
+5.  **Start Eureka Service:** Finally, the playbook uses Docker Compose to start the Eureka server in detached mode.
+
+### c. Troubleshooting
+
+-   **"Permission denied" errors:** Ensure that your SSH user has passwordless `sudo` privileges on all the target servers.
+-   **"Could not resolve hostname" errors:** Ensure that the IP addresses in your `hosts` file are correct and that your Ansible control node can reach them.
+-   **Service fails to start:** Check the logs of the Docker container on the target servers for more information (`docker logs eureka-server`).
+
+### d. Successful Outcome
+
+After a successful run, you will have a fully functional, high-availability Eureka cluster running on your target machines. You can verify this by accessing the Eureka dashboard at `http://<your-eureka-server-ip>:8761`.

--- a/kafka_provisioner/PLAYBOOK-INSTRUCTIONS.md
+++ b/kafka_provisioner/PLAYBOOK-INSTRUCTIONS.md
@@ -1,0 +1,43 @@
+# Playbook Instructions for `kafka_provisioner`
+
+This document provides detailed instructions on how to run the `deploy_kafka.py` script to provision a Kafka cluster.
+
+## 1. `deploy_kafka.py`
+
+This script automates the setup of a horizontally scalable Kafka cluster in High Availability (HA) mode.
+
+### a. How to Run
+
+1.  **Configure your servers:**
+    -   Open the `servers.yaml` file.
+    -   Update the `servers` list with the IP addresses, usernames, and passwords for the servers where you want to install Kafka.
+    -   You can also configure the Kafka version, replication factor, and number of partitions in the `kafka` section of this file.
+
+2.  **Install Python dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+3.  **Run the deployment script:**
+    ```bash
+    python deploy_kafka.py --config servers.yaml
+    ```
+
+### b. Script Steps
+
+1.  **Pre-flight Checks:** The script first connects to each server to verify SSH access and determine the OS distribution (Ubuntu or CentOS).
+2.  **Install Dependencies:** It then ensures that Java is installed on all the servers.
+3.  **Distribute Kafka:** The script downloads the specified version of Kafka, distributes it to all the servers, and creates a symbolic link.
+4.  **Deploy Zookeeper:** It then deploys and configures a Zookeeper ensemble across all the nodes.
+5.  **Deploy Kafka Brokers:** The script then deploys and configures the Kafka brokers on all the nodes.
+6.  **Validate Cluster:** Finally, it runs a validation test to ensure the cluster is working correctly. This involves creating a topic, producing a message, and consuming it.
+
+### c. Troubleshooting
+
+-   **"Failed to connect" errors:** Ensure that the IP addresses, usernames, and passwords in your `servers.yaml` file are correct and that your machine can reach the target servers.
+-   **"Command failed" errors:** Check the logs for more information. The script will log the standard error from any failed commands.
+-   **Validation fails:** If the cluster validation fails, it could be due to a number of issues, such as network connectivity problems between the brokers or a misconfiguration in the `server.properties` file. Check the Kafka logs on the brokers for more information (`/opt/kafka/logs/server.log`).
+
+### d. Successful Outcome
+
+After a successful run, you will have a fully functional Kafka cluster running on your target servers. The script will print "🚀 Kafka Cluster Deployment and Validation Complete! 🚀" to the console.

--- a/microk8s_ansible_deploy/PLAYBOOK-INSTRUCTIONS.md
+++ b/microk8s_ansible_deploy/PLAYBOOK-INSTRUCTIONS.md
@@ -1,0 +1,83 @@
+# Playbook Instructions for `microk8s_ansible_deploy`
+
+This document provides detailed instructions on how to run the Ansible playbooks in this project to deploy a MicroK8s cluster and the application suite.
+
+## 1. `install-cluster.yml`
+
+This playbook installs and configures a MicroK8s cluster on your target servers.
+
+### a. How to Run
+
+1.  **Configure your environment:**
+    -   Open the `ansible/cluster_vars/<your-env>.yml` file (e.g., `ansible/cluster_vars/dev.yml`).
+    -   Update the `kube_masters` and `kube_workers` lists with the IP addresses of your servers.
+    -   Update the `microk8s_version` if you want to install a different version of MicroK8s.
+    -   Ensure you have SSH access to all the servers from your Ansible control node.
+
+2.  **Run the playbook:**
+    ```bash
+    ansible-playbook -i ansible/hosts install-cluster.yml -e "env=<your-env>"
+    ```
+    Replace `<your-env>` with the name of your environment (e.g., `dev`).
+
+### b. Playbook Steps
+
+1.  **Generate `hosts` file:** The playbook first generates an Ansible inventory file (`hosts`) from the `hosts.j2` template using the server IPs from your cluster definition file.
+2.  **Clean up existing MicroK8s installation:** The `microk8s_cleanup` role is run on all nodes to ensure a clean installation. This role will:
+    -   Stop the MicroK8s service.
+    -   Reset the MicroK8s cluster.
+    -   Remove the MicroK8s snap.
+3.  **Install MicroK8s:** The `microk8s_install` role is run on all nodes to install the version of MicroK8s specified in your cluster definition file.
+4.  **Initialize the master node:** The `microk8s_master` role is run on the first master node to initialize the MicroK8s cluster.
+5.  **Join worker nodes:** The `microk8s_worker` role is run on all the worker nodes to join them to the cluster.
+
+### c. Troubleshooting
+
+-   **"Permission denied" errors:** Ensure that your SSH user has passwordless `sudo` privileges on all the target servers.
+-   **"Could not resolve hostname" errors:** Ensure that the IP addresses in your cluster definition file are correct and that your Ansible control node can reach them.
+-   **Installation fails:** If the MicroK8s installation fails, you can check the logs on the target servers for more information (`/var/log/syslog` or `journalctl -u snap.microk8s.daemon-containerd`).
+
+### d. Successful Outcome
+
+After a successful run, you will have a fully functional MicroK8s cluster running on your target servers. You can verify this by running `microk8s kubectl get nodes` on the primary master node.
+
+## 2. `deploy-application.yml`
+
+This playbook deploys the entire application suite to your MicroK8s cluster.
+
+### a. How to Run
+
+1.  **Configure your environment:**
+    -   Ensure that your `ansible/cluster_vars/<your-env>.yml` file is correctly configured with all the necessary service endpoints.
+    -   Review the `ansible/vars/services.yml` file to ensure that all the services you want to deploy are defined.
+    -   Ensure that you have a valid `~/.kube/config` file that points to your MicroK8s cluster. You can get this from your primary master node by running `microk8s config`.
+
+2.  **Run the playbook:**
+    ```bash
+    ansible-playbook deploy-application.yml -e "env=<your-env>"
+    ```
+    Replace `<your-env>` with the name of your environment (e.g., `dev`).
+
+### b. Playbook Steps
+
+1.  **Deploy Elastic Stack:** The `deploy-elastic-stack.yml` playbook is run to deploy Elasticsearch and Kibana using the official Elastic Helm charts.
+2.  **Deploy NGINX Ingress Controller:** The `deploy-ingress.yml` playbook is run to deploy the NGINX Ingress Controller from a set of Kubernetes manifests.
+3.  **Deploy `dataload-service`:** The `deploy-dataload-service.yml` playbook is run to deploy the `dataload-service` and its associated resources (PV, PVC, ConfigMap, Secret).
+4.  **Deploy all other services:** The playbook then loops through the list of services in `vars/services.yml` and deploys each one using the `app_deployer` role. For each service, it will create:
+    -   A `ConfigMap`.
+    -   A `Secret`.
+    -   A `Deployment`.
+    -   A `Service`.
+    -   A `HorizontalPodAutoscaler`.
+    -   An `Ingress` resource (if configured).
+5.  **Create Docker Hub secret:** A Kubernetes secret is created to allow the cluster to pull images from your private Docker Hub repository.
+
+### c. Troubleshooting
+
+-   **"ImagePullBackOff" errors:** Ensure that the Docker Hub secret is created correctly and that the image names and tags in `vars/services.yml` are correct.
+-   **"CrashLoopBackOff" errors:** Check the logs of the failing pods for more information (`kubectl logs <pod-name>`). This is often due to a configuration error (e.g., incorrect database credentials).
+-   **Ingress not working:** Ensure that the NGINX Ingress Controller is running correctly and that the hostnames in your Ingress resources are correct.
+
+### d. Successful Outcome
+
+After a successful run, all your applications will be deployed and running in your MicroK8s cluster. You can verify this by running `kubectl get pods -n <namespace>` and `kubectl get services -n <namespace>`.


### PR DESCRIPTION
This commit adds a `PLAYBOOK-INSTRUCTIONS.md` file to each of the three projects (`microk8s_ansible_deploy`, `kafka_provisioner`, and `eureka_deploy`).

These files provide:
- Full instructions on how to run each playbook.
- A description of what each step in the playbook does.
- Troubleshooting information for common issues.
- A description of the expected outcome of a successful run.